### PR TITLE
Fix for possible notice when using this in static context

### DIFF
--- a/library/RainTpl.php
+++ b/library/RainTpl.php
@@ -248,7 +248,7 @@ class RainTpl{
 				$include_var = self::var_replace( $matches[ 1 ], $loop_level );
 
 				//dynamic include
-				$parsed_code .= '<?php $tpl = new '.__CLASS__.';' .
+				$parsed_code .= '<?php $tpl = new '.get_called_class().';' .
 							 '$tpl_dir_temp = self::$tpl_dir;' .
 							 '$tpl->assign( $this->var );' .
 							 ( !$loop_level ? null : '$tpl->assign( "key", $key'.$loop_level.' ); $tpl->assign( "value", $value'.$loop_level.' );' ).


### PR DESCRIPTION
This includes the adddition of the missing visibility modifiers and a php 5.3-only fix.
This "fix" uses get_called_class() instead of get_class($this) which is unaviable in static context.(Method called on line 158 using self::_compileTemplate)

In RainTPL 2 the method is called non-statical, so this is probably only a temporary fix, even if  it should work on both, static and non-static:
http://www.php.net/manual/de/function.get-called-class.php#94331

See: 
https://github.com/rainphp/raintpl3/issues/12 #12
#11
