### PR TITLE
Re-useable templates

### DIFF
--- a/library/Rain/Tpl.php
+++ b/library/Rain/Tpl.php
@@ -56,7 +56,7 @@ class Tpl{
 	public function draw( $template_file_path, $to_string = false ){
 		extract( $this->var );
 		ob_start();
-		require_once $this->_check_template( $template_file_path );
+		require $this->_check_template( $template_file_path );
 		if( $to_string ) return ob_get_clean(); else echo ob_get_clean();
 	}
 


### PR DESCRIPTION
Use of "require_once" in draw() prevents the same template from being processed again, such as in a loop. Simply changing this to "require" does the trick.

Something to consider might be caching the contents of the fetched files, so that if they have already been included, we load their contents from the cache rather than re-including them. I'm not sure whether it would offer a performance benefit, or a worthwhile one if so.
