### PR TITLE
Accept arrays or template variables in reg. tags

### DIFF
--- a/library/Rain/Tpl.php
+++ b/library/Rain/Tpl.php
@@ -565,6 +565,7 @@ class Tpl{
                                     foreach( static::$conf['registered_tags'] as $tags => $array ){
                                             if( preg_match_all( '/' . $array['parse'] . '/', $html, $matches ) ){
                                                 $found = true;
+                                                unset($matches[0]); // needed to make it work with arrays
                                                 $varray = var_export($matches,1);
 						$tmp = preg_split('/\'/', $varray);
 						foreach($tmp as $key => $reg){


### PR DESCRIPTION
Well... now it can accept arrays or direct variable declaration as parameters of the registered tags.
It changes single quote to double quote in array declaration, this way the content of a variable will merge to the text.

Dont know if the code is the best way to do that, but i think it will improve raintpl.
