### PR TITLE
Created new method for local configuration

### DIFF
--- a/library/Rain/Tpl.php
+++ b/library/Rain/Tpl.php
@@ -162,6 +162,7 @@ class Tpl {
      * @param string, array $setting: name of the setting to configure
      * or associative array type 'setting' => 'value'
      * @param mixed $value: value of the setting to configure
+     * @return \Rain\Tpl $this
      */
     public function objectConfigure($setting, $value = null) {
         if (is_array($setting))
@@ -169,6 +170,8 @@ class Tpl {
                 $this->objectConfigure($key, $value);
         else if (isset(static::$conf[$setting]))
             $this->objectConf[$setting] = $value;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
It creates the functionality to configure an object without altering the configurations of the class or any other object.

To achieve this two new variables were created, they both start as empty arrays.

$this->objectConfigure stores the configurations for that object, the $this->config is generated when the draw method starts by mergin the $this->objectConfigure + static::$conf variable

Also I created a working example on my github with the name example-local-configuration.php please add it too.
