### PR TITLE
deal with joined database results

### DIFF
--- a/library/Rain/Tpl.php
+++ b/library/Rain/Tpl.php
@@ -622,7 +622,8 @@ class Tpl {
             for ($i = 0; $i < count($matches[1]); $i++) {
 
                 $rep = preg_replace('/\[(\${0,1}[a-zA-Z_0-9]*)\]/', '["$1"]', $matches[1][$i]);
-                $rep = preg_replace('/\.(\${0,1}[a-zA-Z_0-9]*)/', '["$1"]', $rep);
+                //$rep = preg_replace('/\.(\${0,1}[a-zA-Z_0-9]*)/', '["$1"]', $rep);
+                $rep = preg_replace( '/\.(\${0,1}[a-zA-Z_0-9]*(?![a-zA-Z_0-9]*(\'|\")))/', '["$1"]', $rep );
                 $html = str_replace($matches[0][$i], $rep, $html);
             }
 


### PR DESCRIPTION
This change corrects a problem when you deal with joined sql results. The field name came in this way "table.field" and  ended parsed to "table[field]".

With this change you can use this way:  {$value["table.field"]} without problems.
