### PR TITLE
compatibility patch

### DIFF
--- a/library/Rain/Tpl.php
+++ b/library/Rain/Tpl.php
@@ -32,7 +32,7 @@ class Tpl{
                                         'registered_tags'	=> array(),
                                         'auto_escape'		=> false,
                                         'tags'              => array(
-                                                                        'loop'			=> array( '({loop.*?})'		, '/{loop="(?<variable>\${0,1}[^"]*)"(?: as (?<key>\$.*?)(?: => (?<value>\$.*?)){0,1}){0,1}}/' ),
+                                                                        'loop'			=> array( '({loop.*?})'		, '/{loop="(?P<variable>\${0,1}[^"]*)"(?: as (?P<key>\$.*?)(?: => (?P<value>\$.*?)){0,1}){0,1}}/' ),
                                                                         'loop_close'	=> array( '({\/loop})'		, '/{\/loop}/' ),
                                                                         'if'			=> array( '({if.*?})'		, '/{if="([^"]*)"}/' ),
                                                                         'elseif'		=> array( '({elseif.*?})'	, '/{elseif="([^"]*)"}/' ),


### PR DESCRIPTION
This commit makes the preg_match named subpattern for the opening {loop} tag backward compatible with PHP versions older than 5.2.2 (PCRE 7.0)
