### PR TITLE
I have added the object tag to PathReplace

### DIFF
--- a/library/Rain/Tpl/Plugin/PathReplace.php
+++ b/library/Rain/Tpl/Plugin/PathReplace.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/../Plugin.php';
 class PathReplace extends \Rain\Tpl\Plugin
 {
 	protected $hooks = array('beforeParse');
-	private $tags = array('a', 'img', 'link', 'script', 'input', 'object');
+	private $tags = array('a', 'img', 'link', 'script', 'input', 'object', 'embed');
 
 	/**
 	 * replace the path of image src, link href and a href.
@@ -70,6 +70,11 @@ class PathReplace extends \Rain\Tpl\Plugin
 		if( in_array( "object", $tags ) ){
 			$exp = array_merge( $exp , array( '/<object(.*?)data=(?:")(http|https)\:\/\/([^"]+?)(?:")/i', '/<object(.*?)data=(?:")([^"]+?)#(?:")/i', '/<object(.*?)data="(.*?)"/', '/<object(.*?)data=(?:\@)([^"]+?)(?:\@)/i' ) );
 			$sub = array_merge( $sub , array( '<object$1data=@$2://$3@', '<object$1data=@$2@' , '<object$1data="' . $path . '$2"', '<object$1data="$2"' ) );
+		}
+
+		if( in_array( "embed", $tags ) ){
+			$exp = array_merge( $exp , array( '/<embed(.*?)src=(?:")(http|https)\:\/\/([^"]+?)(?:")/i', '/<embed(.*?)src=(?:")([^"]+?)#(?:")/i', '/<embed(.*?)src="(.*?)"/', '/<embed(.*?)src=(?:\@)([^"]+?)(?:\@)/i' ) );
+			$sub = array_merge( $sub , array( '<embed$1src=@$2://$3@', '<embed$1src=@$2@', '<embed$1src="' . $path . '$2"', '<embed$1src="$2"' ) );
 		}
 
 		$context->code = preg_replace( $exp, $sub, $html );


### PR DESCRIPTION
I was using the object tag to present svgs and found PathReplace was unable to rewrite the data attribute in them, so I added it.

 <object type="image/svg+xml" width="250" height="160" style="float:left" data="images/trefoil_knot.svg"></object>

 now becomes:

  <object type="image/svg+xml" width="250" height="160" style="float:left" data="templates/redvip/images/trefoil_knot.svg"></object>

Thank you.
