### PR TITLE
{include="filename"} is not work in template

### DIFF
--- a/library/Rain/Tpl/Parser.php
+++ b/library/Rain/Tpl/Parser.php
@@ -356,7 +356,7 @@ class Parser {
                     }
 
                     // reduce the path
-                    $includeTemplate = Parser::reducePath( $includeTemplate );
+                    $includeTemplate = static::reducePath( $includeTemplate );
 
                     if (strpos($matches[1], '$') !== false) {
                         //dynamic include


### PR DESCRIPTION
1. Undefined class (\Rain\Tpl\Tpl)
2. Undefined method (\Rain\Tpl::reducePath ---> \Rain\Tpl\Parser::reducePath)
