### PR TITLE
modifierReplace : whitespace param error

### DIFF
--- a/library/Rain/Tpl/Parser.php
+++ b/library/Rain/Tpl/Parser.php
@@ -607,7 +607,7 @@ class Parser {
 
         $this->blackList($html);
         if (strpos($html,'|') !== false && substr($html,strpos($html,'|')+1,1) != "|") {
-            preg_match('/([\$a-z_A-Z0-9\(\),\[\]"->]+)\|([\$a-z_A-Z0-9\(\):,\[\]"->]+)/i', $html,$result);
+            preg_match('/([\$a-z_A-Z0-9\(\),\[\]"->]+)\|([\$a-z_A-Z0-9\(\):,\[\]"->\s]+)/i', $html,$result);
 
             $function_params = $result[1];
             $explode = explode(":",$result[2]);


### PR DESCRIPTION
I had an error when I did the following:

``` php
 $t = new Tpl;
 $t->assign('arraytest',array('this', 'is', 'a', 'test');
 $t->draw('test');
```

In the template I tried to implode the array with a whitespace:

``` html
{$arraytest|implode:" "}
```

But the result threw an error:

```
Parse error: syntax error, unexpected ';'.......
```

So I added and \s to the preg_match on line 610 of the Parser.php file. 

``` php
 protected function modifierReplace($html) {

        $this->blackList($html);
        if (strpos($html,'|') !== false && substr($html,strpos($html,'|')+1,1) != "|") {
            preg_match('/([\$a-z_A-Z0-9\(\),\[\]"->]+)\|([\$a-z_A-Z0-9\(\):,\[\]"->\s]+)/i', $html,$result);

            $function_params = $result[1];
            $explode = explode(":",$result[2]);
            $function = $explode[0];
            $params = isset($explode[1]) ? "," . $explode[1] : null;

            $html = str_replace($result[0],$function . "(" . $function_params . "$params)",$html);

            if (strpos($html,'|') !== false && substr($html,strpos($html,'|')+1,1) != "|") {
                $html = $this->modifierReplace($html);
            }
        }

        return $html;
    }
```

Result:

```
this is a test
```

Barry
