### PR TITLE
fixed similar key var overlapped

### DIFF
--- a/library/Rain/Tpl/Parser.php
+++ b/library/Rain/Tpl/Parser.php
@@ -575,8 +575,7 @@ class Parser {
                 $rep = preg_replace('/\[(\${0,1}[a-zA-Z_0-9]*)\]/', '["$1"]', $matches[1][$i]);
                 //$rep = preg_replace('/\.(\${0,1}[a-zA-Z_0-9]*)/', '["$1"]', $rep);
                 $rep = preg_replace( '/\.(\${0,1}[a-zA-Z_0-9]*(?![a-zA-Z_0-9]*(\'|\")))/', '["$1"]', $rep );
-		$html = substr_replace($html, $rep, strpos($html, $matches[0][$i]), strlen($matches[0][$i]));
-                //$html = str_replace($matches[0][$i], $rep, $html);
+                $html = substr_replace($html, $rep, strpos($html, $matches[0][$i]), strlen($matches[0][$i]));
             }
 
             // update modifier

--- a/library/Rain/Tpl/Parser.php
+++ b/library/Rain/Tpl/Parser.php
@@ -575,7 +575,8 @@ class Parser {
                 $rep = preg_replace('/\[(\${0,1}[a-zA-Z_0-9]*)\]/', '["$1"]', $matches[1][$i]);
                 //$rep = preg_replace('/\.(\${0,1}[a-zA-Z_0-9]*)/', '["$1"]', $rep);
                 $rep = preg_replace( '/\.(\${0,1}[a-zA-Z_0-9]*(?![a-zA-Z_0-9]*(\'|\")))/', '["$1"]', $rep );
-                $html = str_replace($matches[0][$i], $rep, $html);
+		$html = substr_replace($html, $rep, strpos($html, $matches[0][$i]), strlen($matches[0][$i]));
+                //$html = str_replace($matches[0][$i], $rep, $html);
             }
 
             // update modifier


### PR DESCRIPTION
If you have `{if="$test.key_name && $test.key_namenear"}` then the compiled version : `<?php if( $test["key_name"] && $test["key_name"]near ){ ?>` it should be `<?php if( $test["key_name"] && $test["key_namenear"]){ ?>`
