### PR TITLE
Allow single quotes in modifier replacement.

### DIFF
--- a/library/Rain/Tpl/Parser.php
+++ b/library/Rain/Tpl/Parser.php
@@ -629,7 +629,7 @@ class Parser {
 
         $this->blackList($html);
         if (strpos($html,'|') !== false && substr($html,strpos($html,'|')+1,1) != "|") {
-            preg_match('/([\$a-z_A-Z0-9\(\),\[\]"->]+)\|([\$a-z_A-Z0-9\(\):,\[\]"->\s]+)/i', $html,$result);
+            preg_match('/([\$a-z_A-Z0-9\(\),\[\]"\'->]+)\|([\$a-z_A-Z0-9\(\):,\[\]"\'->\s]+)/i', $html,$result);
 
             $function_params = $result[1];
             $result[2] = str_replace("::", "@double_dot@", $result[2] );


### PR DESCRIPTION
This allows more readable templates when using string arguments inside an HTML attribute.