### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+os: linux
+arch:
+ - amd64
+ - ppc64le
 language: php
 
 php:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,8 @@ php:
   - 5.4
   - 5.5
   - 5.6
+matrix:
+  exclude:
+  - php: 5.3
+  - php: 5.4
+  - php: 5.5


### PR DESCRIPTION
Add support for architecture ppc64le.

Exclude php 5.3, 5.4 and 5.5
  
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3
